### PR TITLE
Allow build for GHC 9.0

### DIFF
--- a/Blaze/Text/Int.hs
+++ b/Blaze/Text/Int.hs
@@ -23,7 +23,10 @@ import Data.Int (Int8, Int16, Int32, Int64)
 import Data.Monoid (mappend, mempty)
 import Data.Word (Word, Word8, Word16, Word32, Word64)
 import GHC.Base (quotInt, remInt)
+#if MIN_VERSION_base(4,15,0)
+#elif
 import GHC.Num (quotRemInteger)
+#endif
 import GHC.Types (Int(..))
 
 #if defined(INTEGER_GMP)


### PR DESCRIPTION
Dear @bos and Hackage Trustees,


- This PR intended to allow build `blaze-textual` package with `base-4.15.0.0` and GHC 9.0.
- `quoteRemInteger` function import was hidden for `base-4.15.0.0`.
- Locally tests were passed:

    ```
    Running 1 test suites...
    Test suite tests: RUNNING...
    Test suite tests: PASS
    Test suite logged to:
    $HOME/blaze-textual/dist-newstyle/build/x86_64-osx/ghc-9.0.1/blaze-textual-0.2.1.0/t/tests/test/blaze-textual-0.2.1.0-tests.log
    1 of 1 test suites (1 of 1 test cases) passed.
    ```
- Closes #13.

Best regards,
@swamp-agr