### PR TITLE
Drop dependency on `time`

### DIFF
--- a/blaze-textual.cabal
+++ b/blaze-textual.cabal
@@ -57,7 +57,6 @@ library
     ghc-prim,
     old-locale,
     text >= 0.11.0.2,
-    time,
     vector
 
   if !flag(native)


### PR DESCRIPTION
Package compiles without it, indeed.